### PR TITLE
Minor comment spelling correction

### DIFF
--- a/src/modules/MailServer.rb
+++ b/src/modules/MailServer.rb
@@ -811,7 +811,7 @@ module Yast
     end
 
     # Return packages needed to be installed and removed during
-    # Autoinstallation to insure module has all needed software
+    # Autoinstallation to ensure module has all needed software
     # installed.
     # @return [Hash] with 2 lists.
     def AutoPackages

--- a/src/modules/YaPI/MailServer.pm
+++ b/src/modules/YaPI/MailServer.pm
@@ -2794,7 +2794,7 @@ sub Overview {
 
 ##
  # Return packages needed to be installed and removed during
- # Autoinstallation to insure module has all needed software
+ # Autoinstallation to ensure module has all needed software
  # installed.
  # @return hash with 2 lists.
  #


### PR DESCRIPTION
Minor comment spelling correction "# Autoinstallation to insure.." to " # Autoinstallation to ensure.."
