### PR TITLE
fix caption string for TLS encryption

### DIFF
--- a/src/include/mail/ui.rb
+++ b/src/include/mail/ui.rb
@@ -397,7 +397,7 @@ module Yast
         VBox(
           WJ_MakeWidget(:outgoing_mail_server),
           # TLS
-          Label(_("The server uses &TLS.")),
+          Label(_("TLS encryption")),
           RadioButtonGroup(
             Id(:TLS),
             HBox(


### PR DESCRIPTION
This fixes bug bnc789894
Note: new pot file required
