### PR TITLE
Add deep_copy calls missing because of a Y2R bug

### DIFF
--- a/src/include/mail/ui.rb
+++ b/src/include/mail/ui.rb
@@ -368,7 +368,7 @@ module Yast
         Mail.Touch(Mail.connection_type != ct)
         Mail.connection_type = ct
 
-        ret = ct == :none ? :none : ret
+        ret = ct == :none ? :none : deep_copy(ret)
       end
       # avoid overriding the choice the user has made
       @preselect_connection_type = nil
@@ -1104,7 +1104,7 @@ module Yast
       WJ_Set(widgets) # TODO hope it is ok to mess it up
       UI.CloseDialog
 
-      ret == :ok ? @fetchmail_item : {}
+      ret == :ok ? deep_copy(@fetchmail_item) : {}
     end
 
 

--- a/src/include/mail/wj.rb
+++ b/src/include/mail/wj.rb
@@ -92,7 +92,9 @@ module Yast
           i = 0
           new_data = Builtins.maplist(data) do |e|
             i = Ops.add(i, 1)
-            Ops.subtract(i, 1) == entryno ? Builtins.union(old_entry, entry) : e
+            Ops.subtract(i, 1) == entryno ?
+              Builtins.union(old_entry, entry) :
+              deep_copy(e)
           end
           touched = true
         else


### PR DESCRIPTION
See https://github.com/yast/y2r/issues/47.
