### PR TITLE
Avoid Unicode in .changes (fix jenkins failure to osc:commit)

### DIFF
--- a/package/yast2-mail.changes
+++ b/package/yast2-mail.changes
@@ -1,7 +1,8 @@
 -------------------------------------------------------------------
 Sun Aug 31 19:19:05 UTC 2014 - varkoly@suse.com
 
-- bnc#889189 - [yast2-users] crashes on "Invalid version format (non-numeric data) at …/perl5/5.20.0/Symbol.pm" 
+- bnc#889189 - [yast2-users] crashes on "Invalid version format
+  (non-numeric data) at .../perl5/5.20.0/Symbol.pm" 
 - 3.1.3
 
 -------------------------------------------------------------------


### PR DESCRIPTION
osc:commit fails in Jenkins with "invalid byte sequence in US-ASCII"
Strictly speaking that is a bug in packaging_rake_tasks but now
I don't want to fix potential problems further down the pipeline.
