### PR TITLE
Fix AutoYaST schema in SLE 12 SP1

### DIFF
--- a/package/yast2-mail.changes
+++ b/package/yast2-mail.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Nov 17 09:21:07 UTC 2015 - igonzalezsosa@suse.com
+
+- Fix validation of AutoYaST profiles (bsc#954412)
+
+-------------------------------------------------------------------
 Thu Dec  4 09:50:26 UTC 2014 - jreidinger@suse.com
 
 - remove X-KDE-Library from desktop file (bnc#899104)

--- a/src/autoyast-rnc/mail.rnc
+++ b/src/autoyast-rnc/mail.rnc
@@ -16,6 +16,8 @@ mail =
     mta &
     outgoing_mail_server? &
     postfix_mda? &
+    smtp_use_TLS? &
+    system_mail_sender? &
     use_amavis? &
     use_dkim? &
     virtual_users?
@@ -92,6 +94,12 @@ postfix_mda =
     mail_SYMBOL_OR_TEXT,
     ( "local" | "procmail" | "imap" )
   }
+
+smtp_use_TLS =
+  element smtp_use_TLS { "yes" | "must" | "no" }
+
+system_mail_sender =
+  element system_mail_sender { text }
 
 use_amavis = element use_amavis { BOOLEAN }
 use_dkim   = element use_dkim   { BOOLEAN }


### PR DESCRIPTION
Fixes [bsc#954412](https://bugzilla.suse.com/show_bug.cgi?id=954412) for SLE 12 SP1. BTW, `SLE-12-GA` branch is merged into `sle-12-sp1-after_release`.