### PR TITLE
bnc#981103 - yast2 mail uses always brackets for relayhost

### DIFF
--- a/package/yast2-mail.changes
+++ b/package/yast2-mail.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue May 24 04:12:36 UTC 2016 - varkoly@suse.com
+
+- bnc#981103 - yast2 mail uses always brackets for relayhost
+- 3.1.8 
+
+-------------------------------------------------------------------
 Wed Mar 16 16:04:55 UTC 2016 - knut.anderssen@suse.com
 
 - Moved cfg_mail.scr to yast2 due to circular dependencies with

--- a/package/yast2-mail.changes
+++ b/package/yast2-mail.changes
@@ -2,6 +2,7 @@
 Tue May 24 04:12:36 UTC 2016 - varkoly@suse.com
 
 - bnc#981103 - yast2 mail uses always brackets for relayhost
+- bnc#981101 - yast2 mail adds POSTFIX_NODAEMON to /etc/sysconfig/postfix
 - 3.1.8 
 
 -------------------------------------------------------------------

--- a/package/yast2-mail.spec
+++ b/package/yast2-mail.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package yast2-mail
 #
-# Copyright (c) 2013 SUSE LINUX Products GmbH, Nuernberg, Germany.
+# Copyright (c) 2016 SUSE LINUX Products GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-mail
-Version:        3.1.7
+Version:        3.1.8
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/mail/ui.rb
+++ b/src/include/mail/ui.rb
@@ -382,7 +382,7 @@ module Yast
       Wizard.SetScreenShotName("mail-21-outgoing")
 
       _TLSnone = Mail.smtp_use_TLS == "no"
-      _TLSuse = Mail.smtp_use_TLS == "yes"
+      _TLSuse  = Mail.smtp_use_TLS == "yes"
       _TLSmust = Mail.smtp_use_TLS == "must"
 
       # what buttons can be used to leave this dialog
@@ -396,6 +396,8 @@ module Yast
       o_contents = VSquash(
         VBox(
           WJ_MakeWidget(:outgoing_mail_server),
+          # OUTGOING NOMX
+          Left(CheckBox(Id(:NOMX), _("Do not make MX lookup for the outgoing mail server."), Mail.outgoing_mail_server_nomx )),
           # TLS
           Label(_("TLS encryption")),
           RadioButtonGroup(
@@ -447,7 +449,8 @@ module Yast
       end
 
       if ret == :next || Builtins.contains(buttons, ret)
-        Mail.smtp_use_TLS = Convert.to_string(UI.QueryWidget(Id(:TLS), :Value))
+        Mail.smtp_use_TLS              = Convert.to_string(UI.QueryWidget(Id(:TLS), :Value))
+        Mail.outgoing_mail_server_nomx = Convert.to_boolean(UI.QueryWidget(Id(:NOMX), :Value))
         WJ_Set(widgets)
       end
       Wizard.RestoreScreenShotName

--- a/src/modules/Mail.rb
+++ b/src/modules/Mail.rb
@@ -403,11 +403,9 @@ module Yast
         @outgoing_mail_server = Convert.to_string(
           SCR.Read(path(".sysconfig.postfix.POSTFIX_RELAYHOST"))
         )
-Builtins.y2milestone("@outgoing_mail_server befor: %1",@outgoing_mail_server)
 	if @outgoing_mail_server.length > 0 and @outgoing_mail_server.delete!("[]") == nil
 	   @outgoing_mail_server_nomx = false
 	end
-Builtins.y2milestone("@outgoing_mail_server after: %1",@outgoing_mail_server)
       else
         return false
       end

--- a/src/modules/Mail.rb
+++ b/src/modules/Mail.rb
@@ -357,7 +357,7 @@ module Yast
       elsif @mta == :postfix
         nc = SCR.Read(path(".sysconfig.postfix.POSTFIX_NODNS")) == "yes"
         ex = SCR.Read(path(".sysconfig.postfix.POSTFIX_DIALUP")) == "yes"
-        nd = SCR.Read(path(".sysconfig.postfix.POSTFIX_NODAEMON")) == "yes"
+        nd = Service.Enabled("postfix")
       else
         return false
       end
@@ -647,19 +647,15 @@ module Yast
       end
 
       if @connection_type == :nodaemon
-        SCR.Write(path(".sysconfig.postfix.POSTFIX_NODAEMON"), "yes")
         SCR.Write(nc_nd, "yes")
         SCR.Write(ex_di, "no")
       elsif @connection_type == :permanent
-        SCR.Write(path(".sysconfig.postfix.POSTFIX_NODAEMON"), "no")
         SCR.Write(nc_nd, "no")
         SCR.Write(ex_di, "no")
       elsif @connection_type == :dialup
-        SCR.Write(path(".sysconfig.postfix.POSTFIX_NODAEMON"), "no")
         SCR.Write(nc_nd, "yes")
         SCR.Write(ex_di, "yes")
       elsif @connection_type == :none
-        SCR.Write(path(".sysconfig.postfix.POSTFIX_NODAEMON"), "no")
         SCR.Write(nc_nd, "yes")
         SCR.Write(ex_di, "no")
       else


### PR DESCRIPTION
Now the MX lookup can be superpressed by checkbox. The default is on.
The brackets should not be set in the field "outgoing mail server". 
For autoyast the syntax was not changed. 