### PR TITLE
BNC#994317 yast2 mailserver does not preserve startup setting

### DIFF
--- a/package/yast2-mail.changes
+++ b/package/yast2-mail.changes
@@ -2,6 +2,7 @@
 Wed Feb  1 16:20:17 UTC 2017 - varkoly@suse.com
 
 - bnc#1022360 Crash during E-Mail-Server setup, when outgoing mailserver is empty
+- bnc#994317 yast2 mailserver does not preserve startup setting 
 - 3.1.11
 
 -------------------------------------------------------------------

--- a/package/yast2-mail.changes
+++ b/package/yast2-mail.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Aug 23 14:00:23 UTC 2016 - varkoly@suse.com
+
+- BNC#994317 yast2 mailserver does not preserve startup setting 
+- 3.1.10
+
+-------------------------------------------------------------------
 Tue Jun  7 11:30:38 UTC 2016 - igonzalezsosa@suse.com
 
 - Stop generating autodocs (fate#320356)

--- a/package/yast2-mail.changes
+++ b/package/yast2-mail.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb  1 16:20:17 UTC 2017 - varkoly@suse.com
+
+- bnc#1022360 Crash during E-Mail-Server setup, when outgoing mailserver is empty
+- 3.1.11
+
+-------------------------------------------------------------------
 Tue Sep 20 07:56:27 UTC 2016 - jreidinger@suse.com
 
 - Reduce build dependencies to speed up build (bsc#999203)

--- a/package/yast2-mail.spec
+++ b/package/yast2-mail.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-mail
-Version:        3.1.10
+Version:        3.1.11
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-mail.spec
+++ b/package/yast2-mail.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-mail
-Version:        3.1.9
+Version:        3.1.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/fillup/sysconfig.mail
+++ b/src/fillup/sysconfig.mail
@@ -31,19 +31,3 @@ MAIL_CREATE_CONFIG="yes"
 # will be accepted.
 #
 SMTPD_LISTEN_REMOTE="no"
-
-## Type:        yesno
-## Default:     no
-#
-# Set this to "yes" if the yast2 mail module must not
-# start with the wizard for asking the 
-# configuration type of the mail server.
-#
-SKIP_ASK="no"
-
-## Type:        string(standard,advanced,undef)
-## Default:     undef
-#
-# This variable contains the type of the mail server configuration.
-#
-CONFIG_TYPE="undef"

--- a/src/modules/Mail.rb
+++ b/src/modules/Mail.rb
@@ -357,7 +357,7 @@ module Yast
       elsif @mta == :postfix
         nc = SCR.Read(path(".sysconfig.postfix.POSTFIX_NODNS")) == "yes"
         ex = SCR.Read(path(".sysconfig.postfix.POSTFIX_DIALUP")) == "yes"
-        nd = Service.Enabled("postfix")
+        nd = ! Service.Enabled("postfix")
       else
         return false
       end
@@ -690,7 +690,7 @@ module Yast
         Service.Enable(service)
         Service.Adjust("amavis", @use_amavis ? "enable" : "disable")
       end
-      Service.Enable(service)
+
       # amavis
       SCR.Write(
         path(".sysconfig.amavis.USE_AMAVIS"),

--- a/src/modules/Mail.rb
+++ b/src/modules/Mail.rb
@@ -747,7 +747,7 @@ module Yast
              l_oms = @outgoing_mail_server.split(/:/)
              if l_oms.length == 2
                 @outgoing_mail_server = "[" + l_oms[0] + "]" + ":" + l_oms[1]
-             else
+             elsif l_oms.length == 1
                 @outgoing_mail_server = "[" + l_oms[0] + "]"
              end
            end


### PR DESCRIPTION
bnc#994317 yast2 mailserver does not preserve startup setting
Remove 2 variables from sysconfig.mail which will not be used anymore.
