### PR TITLE
Fix perl syntax check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 Makefile
 /Makefile.am
+Makefile.am.common
 Makefile.in
 aclocal.m4
 autom4te.cache
@@ -13,6 +14,7 @@ config.sub
 configure
 configure.ac
 depcomp
+doc/
 install-sh
 *.pot
 libtool
@@ -21,9 +23,12 @@ ltmain.sh
 missing
 mkinstalldirs
 stamp-h*
-Makefile.am.common
+test-driver
+tmp.*
 *.ami
 *.bz2
 .dep
-tmp.*
+*.trs
 *.log
+*.out.tmp
+.yardoc/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_install:
 script:
   # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
   # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
-  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-mail-image yast-travis-ruby
+  - docker run -it --rm -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" -e PERL5LIB=./src/servers_non_y2 yast-mail-image yast-travis-ruby


### PR DESCRIPTION
## Problem

Travis [is complaining](https://travis-ci.org/yast/yast-mail/builds/560977124) because 

* The new Perl syntax check

  ```
  Can't locate MasterCFParser.pm in @INC (you may need to install the MasterCFParser module) 
  ```
  
* New files missing in git

  ```
  rake aborted!                                                                                  
  New files missing in git (or add them to to .gitignore):                                       
  .yardoc/checksums                                                                              
  .yardoc/object_types                                                                           
  .yardoc/objects/root.dat                                                                       
  .yardoc/proxy_types                                                                            
  agents/test-mailtable-18487.out.tmp                                                            
  agents/test-mailtable.trs                                                                      
  doc/_index.html                                                                                
  doc/class_list.html                                                                                                                                                                
  ...                  
  ```

## Solution

* Include the `/src/servers_non_y2` in the `PERL5LIB` via Dockerfile (like in #41)
* Update the `.gitignore`