### PR TITLE
bsc#1176645

### DIFF
--- a/package/yast2-mail.changes
+++ b/package/yast2-mail.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep 30 20:03:51 UTC 2020 - Peter Varkoly <varkoly@suse.com>
+
+- bsc#1176645 - Running Yast2 Mail multiple times creates excess
+  brackets in postfix configuration 
+- 4.2.3 
+
+-------------------------------------------------------------------
 Tue Aug 27 18:06:21 CEST 2019 - schubi@suse.de
 
 - Set X-SuSE-YaST-AutoInstResource in desktop file (bsc#144894).

--- a/package/yast2-mail.spec
+++ b/package/yast2-mail.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-mail
-Version:        4.2.2
+Version:        4.2.3
 Release:        0
 Summary:        YaST2 - Mail Configuration
 License:        GPL-2.0-or-later

--- a/src/include/mail/ui.rb
+++ b/src/include/mail/ui.rb
@@ -989,7 +989,9 @@ module Yast
         config = Builtins.add(config, "password", "")
       end
 
-      UI.ChangeWidget(Id(:server), :Value, Ops.get_string(config, "server", ""))
+      server = Ops.get_string(config, "server", "")
+      server.delete!("[]")
+      UI.ChangeWidget(Id(:server), :Value, server)
       UI.ChangeWidget(Id(:user), :Value, Ops.get_string(config, "user", ""))
       UI.ChangeWidget(
         Id(:passw),


### PR DESCRIPTION
Running Yast2 Mail multiple times creates excess brackets in postfix configuration.
The relay server is saved 2 times if smtp_auth is enabled. The brackets must be removed in both places.