### PR TITLE
bsc#1176645

### DIFF
--- a/package/yast2-mail.changes
+++ b/package/yast2-mail.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Oct  1 08:46:13 UTC 2020 - Peter Varkoly <varkoly@suse.com>
+
+- bsc#1176645 - Running Yast2 Mail multiple times creates excess
+  brackets in postfix configuration 
+- 4.3.2  
+
+-------------------------------------------------------------------
 Tue Aug 11 12:08:49 CEST 2020 - schubi@suse.de
 
 - AutoYaST: Added supplements: autoyast(mail) into the spec file

--- a/package/yast2-mail.spec
+++ b/package/yast2-mail.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-mail
-Version:        4.3.1
+Version:        4.3.2
 Release:        0
 Summary:        YaST2 - Mail Configuration
 License:        GPL-2.0-or-later

--- a/src/include/mail/ui.rb
+++ b/src/include/mail/ui.rb
@@ -989,7 +989,9 @@ module Yast
         config = Builtins.add(config, "password", "")
       end
 
-      UI.ChangeWidget(Id(:server), :Value, Ops.get_string(config, "server", ""))
+      server = Ops.get_string(config, "server", "")
+      server.delete!("[]")
+      UI.ChangeWidget(Id(:server), :Value, server)
       UI.ChangeWidget(Id(:user), :Value, Ops.get_string(config, "user", ""))
       UI.ChangeWidget(
         Id(:passw),


### PR DESCRIPTION
Running Yast2 Mail multiple times creates excess brackets in postfix configuration.
The relay server is saved 2 times if smtp_auth is enabled. The brackets must be removed in both places.