### PR TITLE
bsc#1176645 - Running Yast2 Mail multiple times creates excess bracke…

### DIFF
--- a/package/yast2-mail.changes
+++ b/package/yast2-mail.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep 30 19:57:54 UTC 2020 - Peter Varkoly <varkoly@suse.com>
+
+- bsc#1176645 - Running Yast2 Mail multiple times creates excess
+  brackets in postfix configuration 
+- 3.1.12
+
+-------------------------------------------------------------------
 Wed Feb  1 16:20:17 UTC 2017 - varkoly@suse.com
 
 - bnc#1022360 Crash during E-Mail-Server setup, when outgoing mailserver is empty

--- a/package/yast2-mail.spec
+++ b/package/yast2-mail.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-mail
-Version:        3.1.11
+Version:        3.1.12
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/mail/ui.rb
+++ b/src/include/mail/ui.rb
@@ -989,7 +989,9 @@ module Yast
         config = Builtins.add(config, "password", "")
       end
 
-      UI.ChangeWidget(Id(:server), :Value, Ops.get_string(config, "server", ""))
+      server = Ops.get_string(config, "server", "")
+      server.delete!("[]")
+      UI.ChangeWidget(Id(:server), :Value, server)
       UI.ChangeWidget(Id(:user), :Value, Ops.get_string(config, "user", ""))
       UI.ChangeWidget(
         Id(:passw),

--- a/src/servers_non_y2/setup_dkim_verifying.pl
+++ b/src/servers_non_y2/setup_dkim_verifying.pl
@@ -187,4 +187,4 @@ else
 	}
 }
 
-$msc->wramavisiteMasterCF();
+$msc->writeMasterCF();


### PR DESCRIPTION
Running Yast2 Mail multiple times creates excess brackets in postfix configuration.
The relay server is saved 2 times if smtp_auth is enabled. The brackets must be removed in both places.