### PR TITLE
Fix string/symbol and 'masquerade_user' validation

### DIFF
--- a/package/yast2-mail.changes
+++ b/package/yast2-mail.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Oct  9 05:55:29 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- AutoYaST schema (bsc#1174133, bsc#1177496):
+  - Fix validation of string/symbol elements in the schema.
+  - Fix validation of 'masquerade_user' elements.
+- 4.3.3
+
+-------------------------------------------------------------------
 Thu Oct  1 08:46:13 UTC 2020 - Peter Varkoly <varkoly@suse.com>
 
 - bsc#1176645 - Running Yast2 Mail multiple times creates excess

--- a/package/yast2-mail.spec
+++ b/package/yast2-mail.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-mail
-Version:        4.3.2
+Version:        4.3.3
 Release:        0
 Summary:        YaST2 - Mail Configuration
 License:        GPL-2.0-or-later

--- a/src/autoyast-rnc/mail.rnc
+++ b/src/autoyast-rnc/mail.rnc
@@ -32,6 +32,7 @@ mail =
 mail_SYMBOL_OR_TEXT =
   (
     attribute config:type { "symbol" }? |
+    attribute t { "symbol" }? |
     STRING_ATTR
   )
 
@@ -89,9 +90,12 @@ masquerade_users =
   element masquerade_users {
     LIST,
     element masquerade_user {
-      element user { STRING } &
-      element address { STRING } &
-      element comment { STRING }?
+      MAP,
+      (
+        element user { STRING } &
+        element address { STRING } &
+        element comment { STRING }?
+      )
     }*
   }
 


### PR DESCRIPTION
This PR fixes some validation problems that were found in [bsc#1177496](https://bugzilla.suse.com/show_bug.cgi?id=1177496) and [bsc#1174133](https://bugzilla.suse.com/show_bug.cgi?id=1174133).

- String/symbol elements.
- `masquerade_user` map validation.